### PR TITLE
ability to compile without NCURSES

### DIFF
--- a/common/ffi.noe
+++ b/common/ffi.noe
@@ -37,8 +37,6 @@ ffi.cdef[[
   void saveimage(int id, const char *fname);
   int scrget(int scr, int x, int y);
   void scrset(int scr, int x, int y, int val);
-  void setdirectansi(int val);
-  void setconsolewindowtitle(const char *s);
 
   int utf8_numbytes(const char *s, int pos);
   int utf8_decode(const char *s, int pos);
@@ -49,6 +47,13 @@ ffi.cdef[[
   int img_getpixel(int src, int srcX, int srcY);
   void img_setpixel(int src, int srcX, int srcY, unsigned int pix);
   ]]
+
+if not NOCONSOUT then
+  ffi.cdef[[
+    void setdirectansi(int val);
+    void setconsolewindowtitle(const char *s);
+    ]]
+  end
 
 local noteyelib = ffi.os == "Windows" and ffi.load("noteye") or ffi.C
 
@@ -73,7 +78,14 @@ tilexf = noteyelib.addTransform
 tilealpha = noteyelib.addFill
 
 addtile = noteyelib.addTileID
-setconsolewindowtitle = noteyelib.setconsolewindowtitle
+
+if NOCONSOUT then
+  setconsolewindowtitle = function(s) end
+  setdirectansi = function(x) end
+else
+  setconsolewindowtitle = noteyelib.setconsolewindowtitle
+  setdirectansi = noteyelib.setdirectansi
+  end
 
 gchv = noteyelib.getChar
 gba = noteyelib.getBak
@@ -84,7 +96,6 @@ gimg = noteyelib.getImage
 scrget = noteyelib.scrget
 scrset = noteyelib.scrset
 saveimage = noteyelib.saveimage
-setdirectansi = noteyelib.setdirectansi
 
 local fff = tonumber("FFFFFFFF", 16)
 

--- a/common/util.noe
+++ b/common/util.noe
@@ -608,7 +608,7 @@ function addusermod(x)
 
 -- console configuration shortcuts
 function consoleout_gfx()
-  haveascii = fals
+  haveascii = false
   havegfx = true
   end
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ noteye-jni.o: noteye-jni.cpp noteye.h
 
 # dynamic library (used for development)
 ../libnoteye.so: libnoteye.o noteye-jni.o
-	$(CC) -shared -Wl,-soname,libnoteye.so -o ../libnoteye.so libnoteye.o noteye-jni.o -lSDL2 -lSDL2_image $(LUAVER) -lutil -lSDL2_mixer -lSDL2_net -lGL -lGLU $(TGT) -lz -lcurses -lSDL2_ttf
+	$(CC) -shared -Wl,-soname,libnoteye.so -o ../libnoteye.so libnoteye.o noteye-jni.o -lSDL2 -lSDL2_image $(LUAVER) -lutil -lSDL2_mixer -lSDL2_net -lGL $(TGT) -lz -lcurses -lSDL2_ttf
 
 # static library (used for Steam version)
 ../libnoteye.a: libnoteye.o noteye-jni.o
@@ -40,7 +40,7 @@ hydra.o: noteye-curses.h ../hydra/classes.cpp ../hydra/hydra.cpp ../hydra/mainme
 	$(CC) ../hydra/hydra.cpp -c -o hydra.o -DNOTEYE $(CFLAGS) $(TGT) $(DEF) -fPIC
 
 ../noteye: ../libnoteye.so hydra.o noteye-main.cpp ../hydra/hydra-noteye.cpp
-	$(CC) $(DEF) -Wl,-rpath,. -Wl,-rpath,/usr/share/noteye hydra.o noteye-main.cpp -o ../noteye ../libnoteye.so -lGL -lGLU -lSDL2 $(TGT)
+	$(CC) $(DEF) -Wl,-rpath,. -Wl,-rpath,/usr/share/noteye hydra.o noteye-main.cpp -o ../noteye ../libnoteye.so -lGL -lSDL2 $(TGT)
 
 #../noteye: ../libnoteye.so noteye-main.cpp noteye.h
 #	$(CC) -Wl,-rpath,. noteye-main.cpp -o ../noteye ../libnoteye.so

--- a/src/libnoteye.cpp
+++ b/src/libnoteye.cpp
@@ -30,7 +30,9 @@ using namespace std;
 #include "font.cpp"
 #include "process.cpp"
 #include "stream.cpp"
+#ifndef NOCONSOUT
 #include "consout.cpp"
+#endif
 #include "sound.cpp"
 #include "lua.cpp"
 

--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -300,7 +300,12 @@ void initLua() {
   noteye_globalfun("SDL_GetScancodeFromKey", lh_SDL_GetScancodeFromKey);
   noteye_globalfun("SDL_ShowCursor", lh_SDL_ShowCursor);
   
+#ifdef NOCONSOUT
+  noteye_globalint("NOCONSOUT", 1);
+#else
   noteye_globalfun("openconsole", lh_openconsole);
+  noteye_globalfun("refreshconsole", lh_refreshconsole);
+#endif
   
 #ifndef INTERNALONLY
   noteye_globalfun("newprocess", lh_newProcess);
@@ -332,7 +337,6 @@ void initLua() {
   noteye_globalfun("logopen", lh_logopen);
 
   noteye_globalfun("fpp", lh_fpp);
-  noteye_globalfun("refreshconsole", lh_refreshconsole);
 
   noteye_globalfun("isoparam", lh_isoparam);
   noteye_globalfun("isosizes", lh_isosizes);

--- a/src/noteye.h
+++ b/src/noteye.h
@@ -74,10 +74,8 @@ typedef int bool;
 #ifdef OPENGL
 #ifdef MAC
 #include <OpenGL/gl.h>
-#include <OpenGL/glu.h>
 #else
 #include <GL/gl.h>
-#include <GL/glu.h>
 #endif
 #endif
 


### PR DESCRIPTION
if compiled with -DNOCONSOUT, then consout.cpp isn't included, also some lua functions aren't available.
It's needed to compile on platforms that don't have ncurses. In lua haveascii must  be always false.
Didn't test it too much, but hopefully should work in all cases. I added a small workaround in ffi.noe to prevent loading unknown functions.