### PR TITLE
Fix stray keyboard input on focus gain

### DIFF
--- a/common/keymap.noe
+++ b/common/keymap.noe
@@ -745,6 +745,12 @@ function handlekeyevent(ev)
   if currentmodal and currentmodal.handlekey and currentmodal.handlekey(ev) then
     return
     end
+
+  -- ignore key events received less than
+  -- 10 ms of the window gaining focus
+  if ev.timestamp and ev.timestamp - focus_timestamp < 10 then
+    return
+    end
   
   if ev.repeated and cleanupRepeatedKeys then
     delayedKeyEvent = ev

--- a/common/running.noe
+++ b/common/running.noe
@@ -9,6 +9,7 @@ appactive = true
 mouse_inside = true
 mousepressed = false
 ignorefocus = false
+focus_timestamp = 0
 
 -- FPS calculation and control
 
@@ -359,6 +360,7 @@ evhandlers[evWindowEvent] = function(ev)
   if ev.subtype == w.FOCUS_GAINED then
     ignorefocus = true
     appactive = true
+    focus_timestamp = ev.timestamp
     startmusic_lostfocus()
     end
     

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -459,6 +459,7 @@ bool checkEventSDL(lua_State *L, int timeout) {
       SDL_KeyboardEvent& kev(ev.key);
       lua_newtable(L);
       noteye_table_setInt(L, "type", ev.type == SDL_KEYDOWN ? evKeyDown : evKeyUp);
+      noteye_table_setInt(L, "timestamp", kev.timestamp);
       noteye_table_setInt(L, "scancode", kev.keysym.scancode);
       noteye_table_setInt(L, "keycode", kev.keysym.sym);
       // had to change name because "repeat" is reserved in Lua
@@ -479,6 +480,7 @@ bool checkEventSDL(lua_State *L, int timeout) {
     if(ev.type == SDL_WINDOWEVENT) {
       lua_newtable(L);
       noteye_table_setInt(L, "type", evWindowEvent);
+      noteye_table_setInt(L, "timestamp", ev.window.timestamp);
       noteye_table_setInt(L, "subtype", ev.window.event);
       noteye_table_setInt(L, "data1", ev.window.data1);
       noteye_table_setInt(L, "data2", ev.window.data2);


### PR DESCRIPTION
When the application window receives focus while some keys are held
down, SDL will generate key-up events for all the keys that were still
down when the focus was lost. Presumably, this is done so that SDL
doesn't need to track the state of those keys while the game window
isn't focused (which may not even be possible).

The converse is that when the game window is once again focused, SDL
respectively emits key-down events for any keys that are held down
when the focus is gained. This causes the game to think that the
player pressed some keys intended for it, however these keypresses
were actually meant for the window manager or another
application (esp. when combined with modifier keys).

We can detect these generated key presses my taking advantage of the
"timestamp" field in SDL event structures, and comparing the
timestamps of received keyboard events with that of the most recent
focus-in event.

This commit thus fixes the above-described problem by filtering out
keyboard events received less than 10 milliseconds since the last
focus event.