### PR TITLE
Fix using of enhanced Mersenne Twister on mushroom

### DIFF
--- a/hydra/weapons.cpp
+++ b/hydra/weapons.cpp
@@ -1034,7 +1034,7 @@ int ambiAttack(cell *c, int virt) {
   
   if(nheads == 0 && hdub == 0) {
     if(virt == 2) {
-      target->heads = 0;
+      if(target) target->heads = 0;
       return true;
       }
     if(target) addMessage("You slay the "+target->name()+" with your ambidextrous attack!");


### PR DESCRIPTION
Attacking a mushroom by enhanced (+2 and higher) Mersenne Twister
(weapon) crashes the game. Added a null pointer check of the "target".