### PR TITLE
Set text transparency in ttfrender

### DIFF
--- a/src/font.cpp
+++ b/src/font.cpp
@@ -230,6 +230,7 @@ int lh_ttfrender(lua_State *L) {
     else {
       if(bufpos) {
         SDL_Color col;
+        col.a = (ncolor >> 24) & 255;
         col.r = (ncolor >> 16) & 255;
         col.g = (ncolor >> 8 ) & 255;
         col.b = (ncolor >> 0 ) & 255;


### PR DESCRIPTION
This should fix font rendering with SDL2_ttf 2.0.15:
https://www.adom.de/forums/project.php?issueid=6677

It seems that users of ttfrender do set color alpha to 255, but in
case they don't SDL treats alpha 0 as 255, so noteye does not need
special logic to prevent invisible text:
https://github.com/libsdl-org/SDL_ttf/blob/release-2.0.15/SDL_ttf.c#L1644